### PR TITLE
Added setSize()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - '0.11'
   - 'iojs-v1.6.1'
 before_install:
+  - sudo apt-get update
   - sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++
 notifications:
    email: false

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Leaflet-headless
  - Uses [jsdom](https://github.com/tmpvar/jsdom) to fake ad DOM.
  - Uses [canvas](https://github.com/LearnBoost/node-canvas) `Image` implementation to fake images. Note that node-canvas needs some dependencies to be installed: for ubuntu: `sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++`
  - Tiles, Markers and vector layers work well with [leaflet-image](https://github.com/mapbox/leaflet-image)
- - Currently fixed to 1024x1024 map size.
  - It's slow (~4s for the `examples/choropleth/` on my machine).
 
 
@@ -40,6 +39,14 @@ var polyline = L.polyline(latlngs, {renderer: canvas}).addTo(map);
 map.saveImage('test.png', function (filename) {
     console.log('Saved map image to ' + filename);
 });
+```
+
+The default size of images is 1024 x 1024. To adjust this size, a function has been added to set the size of the map 
+
+`L.Map.setSize(width, height)`
+
+```JavaScript
+map.setSize(800, 600);
 ```
 
 ### Other examples:

--- a/index.js
+++ b/index.js
@@ -26,7 +26,11 @@ if (!GLOBAL.L) {
 	// Monkey patch map.getSize to make it work with fixed 1024x1024 elements
 	// jsdom appears to not have clientHeight/clientWidth on elements
 	L.Map.prototype.getSize = function () {
-		return L.point(1024, 1024);
+		if (!this._size || this._sizeChanged) {
+			this._size = new L.Point(1024, 1024);
+			this._sizeChanged = false;
+		}
+		return this._size.clone();
 	};
 
 	// Monkey patch Map to disable animations.
@@ -39,7 +43,14 @@ if (!GLOBAL.L) {
 				zoomAnimation: false,
 				markerZoomAnimation: false
 			});
+
 			return originalMap.prototype.initialize.call(this, id, options);
+		},
+
+		// Set your own size for the output using L.Map.setSize()
+		setSize: function(width, height) {
+			this._size = new L.Point(width, height);
+			return this;
 		},
 
 		saveImage: function (outfilename, callback) {
@@ -65,6 +76,7 @@ if (!GLOBAL.L) {
 			});
 		}
 	});
+
 
 	// leaflet-image checks for instanceof(layer, L.TileLayer.Canvas)
 	// which is not in leaflet-1.0.0-beta.*, this makes the tests work.

--- a/test/test.js
+++ b/test/test.js
@@ -16,23 +16,30 @@ describe('Leaflet-headless', function () {
 	beforeEach(function () {
 		element = document.createElement('div');
 		element.id = 'map';
-		element.style.width = '1024px';
-		element.style.height = '1024px';
 		document.body.appendChild(element);
 
 		map = L.map('map');
 	});
+	
 	afterEach(function () {
 		map.remove();
 	});
 
 	describe('Basic map functions', function () {
-		it('has a size', function () {
+		it('has a default size of 1024x1024', function () {
 			map.setView(latlng, 10);
 
 			var size = map.getSize();
 			size.x.should.equal(1024);
 			size.y.should.equal(1024);
+		});
+
+		it('can change size', function () {
+			map.setView(latlng, 10).setSize(800, 600);
+			
+			var size = map.getSize();
+			size.x.should.equal(800);
+			size.y.should.equal(600);
 		});
 
 		it('can change view', function (done) {
@@ -128,4 +135,5 @@ describe('Leaflet-headless', function () {
 			});
 		});
 	});
+	
 });


### PR DESCRIPTION
#5 This adds the ability to set a size for the generated map image

I'm using the GLOBAL scope to store the size. Maybe there's a better way, but this seems to work. 