### PR TITLE
Bugfix for leaflet 1.1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Leaflet-headless
 [Leaflet](http://leafletjs.com) for node.
 
 
- - Has Leaflet 1.0.3 as dependency.
+ - Has Leaflet 1.1.x as dependency.
  - Uses [jsdom](https://github.com/tmpvar/jsdom) to fake ad DOM.
  - Uses `Image` implementation and canvas from [canvas](https://github.com/LearnBoost/node-canvas).
    Note that node-canvas needs some dependencies to be installed: for ubuntu: `sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++`

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ if (!global.L) {
 
     // Monkey patch Leaflet
     var originalInit = L.Map.prototype.initialize;
-    L.Map.prototype.initialize = function(id, options)
+    L.Map.prototype.initialize = function (id, options)
     {
         options = L.extend(options || {}, {
             fadeAnimation: false,

--- a/index.js
+++ b/index.js
@@ -30,55 +30,53 @@ if (!global.L) {
     L.Icon.Default.imagePath = 'file://' + leafletPath.substring(0, leafletPath.length - scriptLength) + 'images/';
 
     // Monkey patch Leaflet
-    var originalMap = L.Map;
-    L.Map = originalMap.extend({
-        // Override initialize to disable animations.
-        initialize: function (id, options) {
-            options = L.extend(options || {}, {
-                fadeAnimation: false,
-                zoomAnimation: false,
-                markerZoomAnimation: false,
-                preferCanvas: true
-            });
+    var originalInit = L.Map.prototype.initialize;
+    L.Map.prototype.initialize = function(id, options)
+    {
+        options = L.extend(options || {}, {
+            fadeAnimation: false,
+            zoomAnimation: false,
+            markerZoomAnimation: false,
+            preferCanvas: true
+        });
 
-            return originalMap.prototype.initialize.call(this, id, options);
-        },
+        return originalInit.call(this, id, options);
+    }
 
-        // jsdom does not have clientHeight/clientWidth on elements.
-        // Adjust size with L.Map.setSize()
-        getSize: function () {
-            if (!this._size || this._sizeChanged) {
-                this._size = new L.Point(1024, 1024);
-                this._sizeChanged = false;
-            }
-            return this._size.clone();
-        },
-
-        setSize: function (width, height) {
-            this._size = new L.Point(width, height);
-            // reset pixelOrigin
-            this._resetView(this.getCenter(), this.getZoom());
-            return this;
-        },
-
-        saveImage: function (outfilename, callback) {
-            var leafletImage = require('leaflet-image');
-            var fs = require('fs');
-
-            leafletImage(this, function (err, canvas) {
-                if (err) {
-                    console.error(err);
-                    return;
-                }
-                var data = canvas.toDataURL().replace(/^data:image\/\w+;base64,/, '');
-                fs.writeFile(outfilename, new Buffer(data, 'base64'), function () {
-                    if (callback) {
-                        callback(outfilename);
-                    }
-                });
-            });
+    // jsdom does not have clientHeight/clientWidth on elements.
+    // Adjust size with L.Map.setSize()
+    L.Map.prototype.getSize = function () {
+        if (!this._size || this._sizeChanged) {
+            this._size = new L.Point(1024, 1024);
+            this._sizeChanged = false;
         }
-    });
+        return this._size.clone();
+    };
+
+    L.Map.prototype.setSize = function (width, height) {
+        this._size = new L.Point(width, height);
+        // reset pixelOrigin
+        this._resetView(this.getCenter(), this.getZoom());
+        return this;
+    };
+
+    L.Map.prototype.saveImage = function (outfilename, callback) {
+        var leafletImage = require('leaflet-image');
+        var fs = require('fs');
+
+        leafletImage(this, function (err, canvas) {
+            if (err) {
+                console.error(err);
+                return;
+            }
+            var data = canvas.toDataURL().replace(/^data:image\/\w+;base64,/, '');
+            fs.writeFile(outfilename, new Buffer(data, 'base64'), function () {
+                if (callback) {
+                    callback(outfilename);
+                }
+            });
+        });
+    };
 }
 
 module.exports = global.L;


### PR DESCRIPTION
Leaflet 1.1.x broke the extension of Map which resulted in a non-functional library. In the Readme.md example code 

```
var L = require('leaflet-headless');
var map = L.map(document.createElement('div')).setView([52, 4], 10);
var marker = L.marker([52, 4]).addTo(map);

var latlngs = [[52, 4], [54, 4], [54, 6], [52, 6], [52, 4]];
var polyline = L.polyline(latlngs).addTo(map);

map.setSize(800, 600);

map.saveImage('test.png', function (filename) {
    console.log('Saved map image to ' + filename);
});

```

compained about a missing div-id while executing the polyline command:

> /node_modules/leaflet/dist/leaflet-src.js:68
>         obj._leaflet_id = obj._leaflet_id || ++lastId;
>                              ^
> 
> TypeError: Cannot read property '_leaflet_id' of null
>     at stamp (/var/www/node/node_modules/leaflet/dist/leaflet-src.js:68:23)
>     at NewClass.addLayer (/var/www/node/node_modules/leaflet/dist/leaflet-src.js:6441:12)
>     at NewClass.getRenderer (/var/www/node/node_modules/leaflet/dist/leaflet-src.js:12467:9)
>     at NewClass.beforeAdd (/var/www/node/node_modules/leaflet/dist/leaflet-src.js:7545:24)
>     at NewClass.addLayer (/var/www/node/node_modules/leaflet/dist/leaflet-src.js:6448:10)
>     at NewClass.addTo (/var/www/node/node_modules/leaflet/dist/leaflet-src.js:6335:7)
>     at Object.<anonymous> (/var/www/node/test.nd:13:36)
>     at Module._compile (module.js:569:30)
>     at Object.Module._extensions..js (module.js:580:10)
>     at Module.load (module.js:503:32)


After removing the offending command, the injected methods setSize and saveImage were not found.

> /var/www/node/test.nd:15
> map.setSize(800, 600);
>     ^
> 
> TypeError: map.setSize is not a function
>     at Object.<anonymous> (/var/www/node/test.nd:15:5)
>     at Module._compile (module.js:569:30)
>     at Object.Module._extensions..js (module.js:580:10)
>     at Module.load (module.js:503:32)
>     at tryModuleLoad (module.js:466:12)
>     at Function.Module._load (module.js:458:3)
>     at Function.Module.runMain (module.js:605:10)
>     at startup (bootstrap_node.js:158:16)
>     at bootstrap_node.js:575:3

Now leaflet-headless uses normal JavaScript inheritance to add the required functions which seems to work so far.